### PR TITLE
BlazingSQL Check 

### DIFF
--- a/getting_started_notebooks/basics/blazingsql/README.md
+++ b/getting_started_notebooks/basics/blazingsql/README.md
@@ -8,15 +8,24 @@ Demo Python notebooks using BlazingSQL with the RAPIDS AI ecoystem.
 
 ## Getting Started with BlazingSQL
 
-#### Nightly (Recommended) Version
+You can install BlazingSQL simply by running the [python script](https://github.com/rapidsai/notebooks-contrib/tree/branch-0.12/utils/sql_check.py) `sql_check.py` found in the `notebooks-contrib/utils/` directory.
 
-We are undergoing an architecture transition that has made the engine more stable and performant. For that reason we recommend our *Nightly* release over our stable, *Stable* will be updated with the latest cuDF v0.11 release. Find the latest install script [in our docs here](https://docs.blazingdb.com/docs/install-via-conda).
+#### Stable (v0.11)
+
+You can find the latest install scripts [in our docs here](https://docs.blazingdb.com/docs/install-via-conda) or just below.
 
 ```bash
-# for CUDA 9.2
-conda install -c blazingsql-nightly/label/cuda9.2 -c blazingsql-nightly -c rapidsai-nightly -c conda-forge -c defaults blazingsql python=3.7
+# for CUDA 9.2 & Python 3.7
+conda install -c blazingsql/label/cuda9.2 -c blazingsql -c rapidsai -c nvidia -c conda-forge -c defaults blazingsql python=3.7 cudatoolkit=9.2
 
-# for CUDA 10.0
-conda install -c blazingsql-nightly/label/cuda10.0 -c blazingsql-nightly -c rapidsai-nightly -c conda-forge -c defaults blazingsql python=3.7
+# for CUDA 10.0 & Python 3.7
+conda install -c blazingsql/label/cuda10.0 -c blazingsql -c rapidsai -c nvidia -c conda-forge -c defaults blazingsql python=3.7 cudatoolkit=10.0
 ```
-Note: BlazingSQL-Nightly is supported only on Linux, and with Python versions 3.6 or 3.7.
+
+#### Nightly 
+
+```bash
+conda install -c blazingsql-nightly/label/cuda10.0 -c blazingsql-nightly -c rapidsai-nightly -c conda-forge -c defaults blazingsql
+```
+
+Note: BlazingSQL-Nightly is supported only on Linux, with CUDA 9.2 or 10 and Python 3.6 or 3.7.

--- a/getting_started_notebooks/basics/blazingsql/federated_query_demo.ipynb
+++ b/getting_started_notebooks/basics/blazingsql/federated_query_demo.ipynb
@@ -25,25 +25,30 @@
     "id": "aMwNKxePSwOp"
    },
    "source": [
-    "## Import packages "
+    "#### BlazingSQL install check\n",
+    "The next cell checks that you have BlazingSQL installed, and offers to install it if not (making sure the notebook will run as expected)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "You've got BlazingSQL set up perfectly! Let's get started with SQL in RAPIDS AI!\n"
+     ]
+    }
+   ],
    "source": [
-    "# Notebooks-contrib test \n",
-    "import os\n",
-    "try:\n",
-    "    import matplotlib\n",
-    "except ModuleNotFoundError:\n",
-    "    os.system('conda install -y matplotlib')\n",
-    "    import matplotlib\n",
-    "\n",
-    "# import BlazingSQL\n",
-    "from blazingsql import BlazingContext"
+    "import sys \n",
+    "# point import path notebooks-contrib/utils\n",
+    "sys.path.append('../../../utils/')\n",
+    "from sql_check import bsql_start\n",
+    "# check that BlazingSQL is installed\n",
+    "bsql_start()"
    ]
   },
   {
@@ -76,6 +81,8 @@
     }
    ],
    "source": [
+    "from blazingsql import BlazingContext\n",
+    "\n",
     "bc = BlazingContext()"
    ]
   },
@@ -1233,7 +1240,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,

--- a/getting_started_notebooks/basics/blazingsql/getting_started_with_blazingsql.ipynb
+++ b/getting_started_notebooks/basics/blazingsql/getting_started_with_blazingsql.ipynb
@@ -17,26 +17,30 @@
     "id": "aMwNKxePSwOp"
    },
    "source": [
-    "## Import packages "
+    "#### BlazingSQL install check\n",
+    "The next cell checks that you have BlazingSQL installed, and offers to install it if not (making sure the notebook will run as expected)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "You've got BlazingSQL set up perfectly! Let's get started with SQL in RAPIDS AI!\n"
+     ]
+    }
+   ],
    "source": [
-    "# Notebooks-contrib test \n",
-    "import os\n",
-    "try:\n",
-    "    import matplotlib\n",
-    "except ModuleNotFoundError:\n",
-    "    os.system('conda install -y matplotlib')\n",
-    "    import matplotlib\n",
-    "\n",
-    "# import BlazingSQL & cuDF\n",
-    "from blazingsql import BlazingContext\n",
-    "import cudf"
+    "import sys \n",
+    "# point import path notebooks-contrib/utils\n",
+    "sys.path.append('../../../utils/')\n",
+    "from sql_check import bsql_start\n",
+    "# check that BlazingSQL is installed\n",
+    "bsql_start()"
    ]
   },
   {
@@ -70,6 +74,9 @@
     }
    ],
    "source": [
+    "import cudf\n",
+    "from BlazingSQL import BlazingContext\n",
+    "\n",
     "bc = BlazingContext()"
    ]
   },
@@ -393,6 +400,19 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# query events in San Francisco, CA\n",
+    "gdf = bc.sql(\"SELECT * FROM music where LOCATION = 'San Francisco'\")\n",
+    "\n",
+    "# sample 7 rows by converting to pandas \n",
+    "gdf.to_pandas().sample(7)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
@@ -429,7 +449,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,

--- a/intermediate_notebooks/examples/blazingsql/README.md
+++ b/intermediate_notebooks/examples/blazingsql/README.md
@@ -9,17 +9,24 @@ Demo Python notebooks using BlazingSQL with the RAPIDS AI ecoystem.
 
 ## Getting Started with BlazingSQL
 
-You can install BlazingSQL simply by running the [shell script](https://github.com/rapidsai/notebooks-contrib/tree/branch-0.12/utils) `now_were_blazing.sh` found in the `notebooks-contrib/utils/` directory.
+You can install BlazingSQL simply by running the [python script](https://github.com/rapidsai/notebooks-contrib/tree/branch-0.12/utils/sql_check.py) `sql_check.py` found in the `notebooks-contrib/utils/` directory.
 
-#### Nightly (Recommended) Version
+#### Stable (v0.11)
 
-We are undergoing an architecture transition that has made the engine more stable and performant. For that reason we recommend our *Nightly* release over our stable, *Stable* will be updated with the latest cuDF v0.11 release. Find the latest install script [in our docs here](https://docs.blazingdb.com/docs/install-via-conda).
+You can find the latest install scripts [in our docs here](https://docs.blazingdb.com/docs/install-via-conda) or just below.
 
 ```bash
-# for CUDA 9.2
-conda install -c blazingsql-nightly/label/cuda9.2 -c blazingsql-nightly -c rapidsai-nightly -c conda-forge -c defaults blazingsql python=3.7
+# for CUDA 9.2 & Python 3.7
+conda install -c blazingsql/label/cuda9.2 -c blazingsql -c rapidsai -c nvidia -c conda-forge -c defaults blazingsql python=3.7 cudatoolkit=9.2
 
-# for CUDA 10.0
-conda install -c blazingsql-nightly/label/cuda10.0 -c blazingsql-nightly -c rapidsai-nightly -c conda-forge -c defaults blazingsql python=3.7
+# for CUDA 10.0 & Python 3.7
+conda install -c blazingsql/label/cuda10.0 -c blazingsql -c rapidsai -c nvidia -c conda-forge -c defaults blazingsql python=3.7 cudatoolkit=10.0
 ```
-Note: BlazingSQL-Nightly is supported only on Linux, and with Python versions 3.6 or 3.7.
+
+#### Nightly 
+
+```bash
+conda install -c blazingsql-nightly/label/cuda10.0 -c blazingsql-nightly -c rapidsai-nightly -c conda-forge -c defaults blazingsql
+```
+
+Note: BlazingSQL-Nightly is supported only on Linux, with CUDA 9.2 or 10 and Python 3.6 or 3.7.

--- a/intermediate_notebooks/examples/blazingsql/graphistry_netflow_demo.ipynb
+++ b/intermediate_notebooks/examples/blazingsql/graphistry_netflow_demo.ipynb
@@ -18,25 +18,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Imports"
+    "#### BlazingSQL install check\n",
+    "The next cell checks that you have BlazingSQL installed, and offers to install it if not (making sure the notebook will run as expected)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "You've got BlazingSQL set up perfectly! Let's get started with SQL in RAPIDS AI!\n"
+     ]
+    }
+   ],
    "source": [
-    "# Notebooks-contrib test \n",
-    "import os\n",
-    "try:\n",
-    "    import matplotlib\n",
-    "except ModuleNotFoundError:\n",
-    "    os.system('conda install -y matplotlib')\n",
-    "    import matplotlib\n",
-    "    \n",
-    "# import blazingsql\n",
-    "from blazingsql import BlazingContext "
+    "import sys \n",
+    "# point import path notebooks-contrib/utils\n",
+    "sys.path.append('../../../utils/')\n",
+    "from sql_check import bsql_start\n",
+    "# check that BlazingSQL is installed\n",
+    "bsql_start()"
    ]
   },
   {
@@ -62,6 +67,7 @@
     }
    ],
    "source": [
+    "from blazingsql import BlazingContext\n",
     "bc = BlazingContext()"
    ]
   },
@@ -73,7 +79,9 @@
    },
    "source": [
     "### Create & Query Tables\n",
-    "In this next cell we identify the full path to the data we've downloaded."
+    "BlazingSQL relies on the full path to the data to create tables. \n",
+    "\n",
+    "In this next cell, we identify the full path to this demo's data which is stored in this repo under the `/data/` directory."
    ]
   },
   {
@@ -634,7 +642,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.5"
   },
   "mimetype": "text/x-python",
   "name": "python",

--- a/intermediate_notebooks/examples/blazingsql/taxi_fare_prediction.ipynb
+++ b/intermediate_notebooks/examples/blazingsql/taxi_fare_prediction.ipynb
@@ -13,9 +13,37 @@
     "\n",
     "In this notebook, we will cover: \n",
     "- How to read and query csv files with cuDF and BlazingSQL.\n",
-    "- How to implement a linear regression model with cuML.\n",
-    "\n",
-    "![Impression](https://www.google-analytics.com/collect?v=1&tid=UA-39814657-5&cid=555&t=event&ec=guides&ea=taxi_fare_prediction&dt=taxi_fare_prediction)\n"
+    "- How to implement a linear regression model with cuML."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### BlazingSQL install check\n",
+    "The next cell checks that you have BlazingSQL installed, and offers to install it if not (making sure the notebook will run as expected)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "You've got BlazingSQL set up perfectly! Let's get started with SQL in RAPIDS AI!\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys \n",
+    "# point import path notebooks-contrib/utils\n",
+    "sys.path.append('../../../utils/')\n",
+    "from sql_check import bsql_start\n",
+    "# check that BlazingSQL is installed\n",
+    "bsql_start()"
    ]
   },
   {
@@ -34,15 +62,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Notebooks-contrib test \n",
-    "import os\n",
-    "try:\n",
-    "    import matplotlib\n",
-    "except ModuleNotFoundError:\n",
-    "    os.system('conda install -y matplotlib')\n",
-    "    import matplotlib\n",
-    "    \n",
-    "# Import RAPIDS AI stack\n",
     "import cudf\n",
     "from cuml import LinearRegression\n",
     "from blazingsql import BlazingContext"
@@ -1122,7 +1141,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,

--- a/intermediate_notebooks/examples/blazingsql/vs_pyspark_netflow.ipynb
+++ b/intermediate_notebooks/examples/blazingsql/vs_pyspark_netflow.ipynb
@@ -18,31 +18,32 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "0guvG6Ws_zmX"
-   },
+   "metadata": {},
    "source": [
-    "## Import packages "
+    "#### BlazingSQL install check\n",
+    "The next cell checks that you have BlazingSQL installed, and offers to install it if not (making sure the notebook will run as expected)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "You've got BlazingSQL set up perfectly! Let's get started with SQL in RAPIDS AI!\n"
+     ]
+    }
+   ],
    "source": [
-    "# Notebooks-contrib test \n",
-    "import os\n",
-    "try:\n",
-    "    import matplotlib\n",
-    "except ModuleNotFoundError:\n",
-    "    os.system('conda install -y matplotlib')\n",
-    "    import matplotlib\n",
-    "\n",
-    "# notebook imports\n",
-    "import cudf\n",
-    "from blazingsql import BlazingContext"
+    "import sys \n",
+    "# point import path notebooks-contrib/utils\n",
+    "sys.path.append('../../../utils/')\n",
+    "from sql_check import bsql_start\n",
+    "# check that BlazingSQL is installed\n",
+    "bsql_start()"
    ]
   },
   {
@@ -76,6 +77,9 @@
     }
    ],
    "source": [
+    "import cudf\n",
+    "from blazingsql import BlazingContext\n",
+    "\n",
     "bc = BlazingContext()"
    ]
   },
@@ -119,7 +123,8 @@
    ],
    "source": [
     "# save nf-chunk2 to data folder, may take a few minutes to download\n",
-    "!wget -P data/ https://blazingsql-colab.s3.amazonaws.com/netflow_data/nf-chunk2.csv "
+    "!mkdir data\n",
+    "!wget -P ../data/ https://blazingsql-colab.s3.amazonaws.com/netflow_data/nf-chunk2.csv "
    ]
   },
   {
@@ -696,7 +701,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,

--- a/utils/sql_check.py
+++ b/utils/sql_check.py
@@ -1,0 +1,55 @@
+# Notebooks-contrib test 
+import os
+import sys  
+
+
+def bsql_start():
+    """
+    set up users to use SQL in the RAPIDS AI ecosystem
+        > try to import BlazingContext from BlazingSQL
+        > offer to install BlazingSQL if module not found
+    BlazingSQL prereqs: 
+        > Conda: https://docs.blazingdb.com/docs/install-via-conda#section-conda-prerequisites
+        > Docker: https://docs.blazingdb.com/docs/install-via-docker#section-docker-hub-prerequisites
+    latest install scripts: 
+        > Conda: https://docs.blazingdb.com/docs/install-via-conda
+        > Docker: https://docs.blazingdb.com/docs/install-via-docker
+        > Source: https://docs.blazingdb.com/docs/build-from-source
+    """
+    # is BlazingSQL installed?
+    try:
+        # from blazingsql import BlazingContext
+        print("You've got BlazingSQL set up perfectly! Let's get started with SQL in RAPIDS AI!")
+    # BlazingSQL not found
+    except ModuleNotFoundError:
+        # install BlazingSQL?
+        ask = input('Unable to locate BlazingSQL, would you like to install it now? [y/n]')
+        # account for input error (extra spaces or CAPS)
+        ask = ask.strip().lower()
+        # yes install now (account for error input w/ strip & lower)
+        if (ask == 'y') or (ask == 'yes'):      
+            # tag BlazingSQL conda install script
+            b = "conda install -c blazingsql/label/cuda10.0 -c blazingsql" 
+            b += ' -c rapidsai -c nvidia -c conda-forge -c defaults '
+            b += "blazingsql python=3.7 cudatoolkit=10.0"  # CUDA 10, Python 3.7 (BlazingSQL also supports CUDA 9.2)
+            # check python version
+            py = sys.version.split('.')[1]
+            # are we on python 3.6?
+            if py == '6':
+                # adjust to 3.6 install script
+                b = b.replace('python=3.7', 'python=3.6')
+            # what's going on?
+            print('Installing BlazingSQL, this may take a few minutes.')
+            # install BlazingSQL
+            os.system(b)
+        # no, don't install now
+        else:
+            # indicate so
+            docs = 'https://docs.blazingdb.com/docs/install-via-conda'
+            print(f'Ok, not installing now.\nTo download later simply rerun this script or go to {docs}')
+            
+            
+if __name__=='__main__':
+    # check environment for BlazingSQL
+    check = bsql_start()
+    print(check)


### PR DESCRIPTION
Update notebooks-contrib test in each of 5 BlazingSQL notebooks to check (w/ Conda) if BlazingSQL is installed and offer to install it if not. Adds new BlazingSQL install script `sql_check.py`.

Resolves [issue](https://github.com/rapidsai/notebooks-contrib/pull/235#pullrequestreview-336059259) in: https://github.com/rapidsai/notebooks-contrib/pull/235